### PR TITLE
Chapter3 exercises

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
     "whatwg-fetch": "^3.0.0"
   }
 }

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -119,6 +119,8 @@ export const AppointmentForm = ({
     service,
     startsAt,
   });
+  const [error, setError] = useState('false');
+
   const handleStylistChange = ({ target: { value } }) => setAppointment(
     {
       ...appointment,
@@ -155,12 +157,14 @@ export const AppointmentForm = ({
     if (result && result.ok) {
       const appointmentWithId = await result.json();
       onSave(appointmentWithId);
+    } else {
+      setError('true');
     }
   };
 
   return (
     <form id="appointment" onSubmit={handleSubmit}>
-
+      { error ? <Error /> : null}
       <label htmlFor="stylist">Stylist</label>
       <select
         name="stylist"
@@ -198,6 +202,9 @@ export const AppointmentForm = ({
     </form>
   );
 };
+
+const Error = () => <div className="error">an error occured</div>;
+
 AppointmentForm.defaultProps = {
   availableTimeSlots: {},
   today: new Date(),

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -104,7 +104,6 @@ const TimeSlotTable = ({
 export const AppointmentForm = ({
   selectableServices,
   service,
-  onSubmit,
   salonOpensAt,
   salonClosesAt,
   today,
@@ -146,8 +145,7 @@ export const AppointmentForm = ({
   };
 
   const handleSubmit = () => {
-    onSubmit(appointment);
-    fetch('/appointments', {
+    window.fetch('/appointments', {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
@@ -196,8 +194,6 @@ export const AppointmentForm = ({
   );
 };
 AppointmentForm.defaultProps = {
-  fetch: async () => {},
-  onSubmit: () => {},
   availableTimeSlots: {},
   today: new Date(),
   salonOpensAt: 9,

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -155,10 +155,10 @@ export const AppointmentForm = ({
       body: JSON.stringify(appointment),
     });
     if (result && result.ok) {
-      const appointmentWithId = await result.json();
-      onSave(appointmentWithId);
+      setError(false);
+      onSave();
     } else {
-      setError('true');
+      setError(true);
     }
   };
 

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -119,7 +119,7 @@ export const AppointmentForm = ({
     service,
     startsAt,
   });
-  const [error, setError] = useState('false');
+  const [error, setError] = useState(false);
 
   const handleStylistChange = ({ target: { value } }) => setAppointment(
     {

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -151,6 +151,7 @@ export const AppointmentForm = ({
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(appointment),
     });
   };
 

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -111,7 +111,7 @@ export const AppointmentForm = ({
   startsAt,
   selectableStylists,
   stylist,
-  fetch,
+  onSave,
 }) => {
   const dates = weeklyDateValues(today);
   const [appointment, setAppointment] = useState({
@@ -144,13 +144,15 @@ export const AppointmentForm = ({
     return selectedStylist.services;
   };
 
-  const handleSubmit = () => {
-    window.fetch('/appointments', {
+  const handleSubmit = async () => {
+    const result = await window.fetch('/appointments', {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(appointment),
     });
+    const appointmentWithId = await result.json();
+    onSave(appointmentWithId);
   };
 
   return (
@@ -211,4 +213,5 @@ AppointmentForm.defaultProps = {
     { name: 'Pepe', services: ['Cut', 'Beard trim', 'Cut & Beard trim'] },
     { name: 'Paul', services: ['Cut', 'Extensions', 'Cut & Color', 'Blow-dry'] },
     { name: 'Sara', services: ['Cut', 'Beard trim', 'Cut & Beard trim', 'Extensions', 'Blow-dry', 'Cut & color'] }],
+  onSave: () => {},
 };

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import 'whatwg-fetch';
 
 const timeIncrement = (numTimes, startTime, increment) => Array(numTimes)
   .fill([startTime])
@@ -111,6 +112,7 @@ export const AppointmentForm = ({
   startsAt,
   selectableStylists,
   stylist,
+  fetch,
 }) => {
   const dates = weeklyDateValues(today);
   const [appointment, setAppointment] = useState({
@@ -143,8 +145,17 @@ export const AppointmentForm = ({
     return selectedStylist.services;
   };
 
+  const handleSubmit = () => {
+    onSubmit(appointment);
+    fetch('/appointments', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
   return (
-    <form id="appointment" onSubmit={() => onSubmit(appointment)}>
+    <form id="appointment" onSubmit={handleSubmit}>
 
       <label htmlFor="stylist">Stylist</label>
       <select
@@ -184,6 +195,7 @@ export const AppointmentForm = ({
   );
 };
 AppointmentForm.defaultProps = {
+  fetch: async () => {},
   availableTimeSlots: {},
   today: new Date(),
   salonOpensAt: 9,

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -197,6 +197,7 @@ export const AppointmentForm = ({
 };
 AppointmentForm.defaultProps = {
   fetch: async () => {},
+  onSubmit: () => {},
   availableTimeSlots: {},
   today: new Date(),
   salonOpensAt: 9,

--- a/src/AppointmentForm.js
+++ b/src/AppointmentForm.js
@@ -144,15 +144,18 @@ export const AppointmentForm = ({
     return selectedStylist.services;
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e) => {
+    e.preventDefault();
     const result = await window.fetch('/appointments', {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(appointment),
     });
-    const appointmentWithId = await result.json();
-    onSave(appointmentWithId);
+    if (result && result.ok) {
+      const appointmentWithId = await result.json();
+      onSave(appointmentWithId);
+    }
   };
 
   return (

--- a/src/CustomerForm.js
+++ b/src/CustomerForm.js
@@ -19,6 +19,7 @@ export const CustomerForm = ({
     });
     if (result && result.ok) {
       const customerWithId = await result.json();
+      setError(false);
       onSave(customerWithId);
     } else {
       setError(true);

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -119,25 +119,29 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submitted', async () => {
-      const submitSpy = spy();
+      const fetchSpy = spy();
 
       render(<AppointmentForm
         service="Blow-dry"
-        onSubmit={submitSpy.fn}
+        fetch={fetchSpy.fn}
+        onSubmit={() => {}}
       />);
       submit(form('appointment'));
-      expect(submitSpy).toHaveBeenCalled();
-      expect(submitSpy.receivedArgument(0)[fieldName]).toEqual('Blow-dry');
+      const fetchOpts = fetchSpy.receivedArgument(1);
+      expect(JSON.parse(fetchOpts.body)[fieldName]).toEqual('Blow-dry');
     });
 
     it('saves a new value when submitted', async () => {
-      expect.hasAssertions();
+      const fetchSpy = spy();
       render(<AppointmentForm
         service="Blow-dry"
-        onSubmit={(props) => expect(props.service).toEqual('Beard trim')}
+        fetch={fetchSpy.fn}
+        onSubmit={() => {}}
       />);
       change(field(formId, fieldName), { target: { value: 'Beard trim' } });
       submit(form('appointment'));
+      const fetchOpts = fetchSpy.receivedArgument(1);
+      expect(JSON.parse(fetchOpts.body)[fieldName]).toEqual('Beard trim');
     });
   });
 
@@ -210,22 +214,28 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submitted', async () => {
-      expect.hasAssertions();
+      const fetchSpy = spy();
       render(<AppointmentForm
         stylist="Pepe"
-        onSubmit={(props) => expect(props.stylist).toEqual('Pepe')}
+        onSubmit={() => {}}
+        fetch={fetchSpy.fn}
       />);
-      await ReactTestUtils.Simulate.submit(form('appointment'));
+      submit(form('appointment'));
+      const fetchOpts = fetchSpy.receivedArgument(1);
+      expect(JSON.parse(fetchOpts.body)[fieldName]).toEqual('Pepe');
     });
 
     it('saves a new value when submitted', async () => {
-      expect.hasAssertions();
+      const fetchSpy = spy();
       render(<AppointmentForm
         stylist="Pepe"
-        onSubmit={(props) => expect(props.stylist).toEqual('Sara')}
+        onSubmit={() => {}}
+        fetch={fetchSpy.fn}
       />);
       change(field(formId, fieldName), { target: { value: 'Sara' } });
       submit(form('appointment'));
+      const fetchOpts = fetchSpy.receivedArgument(1);
+      expect(JSON.parse(fetchOpts.body)[fieldName]).toEqual('Sara');
     });
 
     it('filters the services list according to stylist\'s services', () => {

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -21,6 +21,19 @@ describe('AppointmentForm', () => {
     };
   };
 
+  expect.extend({
+    toHaveBeenCalled(received) {
+      if (received.receivedArguments() === undefined) {
+        return {
+          pass: false,
+          message: () => 'Spy was not called',
+        };
+      }
+      return { pass: true, message: 'Spy was called.' };
+    },
+
+  });
+
   beforeEach(() => {
     ({
       render, container, field, form, labelFor, change, submit,
@@ -93,7 +106,7 @@ describe('AppointmentForm', () => {
       expect(field(formId, fieldName).id).toEqual(fieldName);
     });
 
-    it.only('saves existing value when submitted', async () => {
+    it('saves existing value when submitted', async () => {
       const submitSpy = spy();
 
       render(<AppointmentForm
@@ -101,7 +114,7 @@ describe('AppointmentForm', () => {
         onSubmit={submitSpy.fn}
       />);
       submit(form('appointment'));
-      expect(submitSpy.receivedArguments()).toBeDefined();
+      expect(submitSpy).toHaveBeenCalled();
       expect(submitSpy.receivedArgument(0)[fieldName]).toEqual('Blow-dry');
     });
 

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -26,17 +26,20 @@ describe('AppointmentForm', () => {
       );
     };
     const labelFor = (formElement) => container.querySelector(`label[for="${formElement}"]`);
+
     it('renders as a select box', () => {
       render(<AppointmentForm />);
       expect(field('service')).not.toBeNull();
       expect(field('service').tagName).toEqual('SELECT');
     });
+
     it('initially has a blank value chosen', () => {
       render(<AppointmentForm />);
       const firstNode = field('service').childNodes[0];
       expect(firstNode.value).toEqual('');
       expect(firstNode.selected).toBeTruthy();
     });
+
     it('lists all salon services', () => {
       const selectableServices = [
         'Cut',
@@ -54,6 +57,7 @@ describe('AppointmentForm', () => {
         expect.arrayContaining(selectableServices)
       );
     });
+
     it('preselects the existing value', () => {
       const services = ['Cut', 'Blow-dry'];
       render(<AppointmentForm
@@ -63,22 +67,27 @@ describe('AppointmentForm', () => {
       const option = findOption(field('service'), 'Blow-dry');
       expect(option.selected).toBeTruthy();
     });
+
     it('renders a label', () => {
       render(<AppointmentForm />);
       expect(labelFor('service')).not.toBeNull();
     });
+
     it('assigns an id that matches the label id', () => {
       render(<AppointmentForm />);
       expect(field('service').id).toEqual('service');
     });
+
     it('saves existing value when submitted', async () => {
       expect.hasAssertions();
       render(<AppointmentForm
         service="Blow-dry"
         onSubmit={(props) => expect(props.service).toEqual('Blow-dry')}
       />);
+
       await ReactTestUtils.Simulate.submit(form('appointment'));
     });
+
     it('saves a new value when submitted', async () => {
       expect.hasAssertions();
       render(<AppointmentForm
@@ -113,16 +122,19 @@ describe('AppointmentForm', () => {
       expect(field('stylist')).not.toBeNull();
       expect(field('stylist').tagName).toEqual('SELECT');
     });
+
     it('renders a label for the input field', () => {
       render(<AppointmentForm />);
       expect(labelFor('stylist')).not.toBeNull();
     });
+
     it('initially has a blank value chosen', () => {
       render(<AppointmentForm />);
       const firstNode = field('stylist').childNodes[0];
       expect(firstNode.value).toEqual('');
       expect(firstNode.selected).toBeTruthy();
     });
+
     it('lists all stylists', () => {
       render(
         <AppointmentForm
@@ -137,6 +149,7 @@ describe('AppointmentForm', () => {
         expect.arrayContaining(selectableStylists.map((s) => s.name))
       );
     });
+
     it('preselects the existing value', () => {
       const stylists = [{ name: 'Jon', services: ['Cut', 'Cut & color'] },
         { name: 'Jeff', services: ['Extensions', 'Cut'] }];
@@ -147,10 +160,12 @@ describe('AppointmentForm', () => {
       const option = findOption(field('stylist'), 'Jon');
       expect(option.selected).toBeTruthy();
     });
+
     it('assigns an id that matches the label id', () => {
       render(<AppointmentForm />);
       expect(field('stylist').id).toEqual('stylist');
     });
+
     it('saves existing value when submitted', async () => {
       expect.hasAssertions();
       render(<AppointmentForm
@@ -159,6 +174,7 @@ describe('AppointmentForm', () => {
       />);
       await ReactTestUtils.Simulate.submit(form('appointment'));
     });
+
     it('saves a new value when submitted', async () => {
       expect.hasAssertions();
       render(<AppointmentForm
@@ -168,6 +184,7 @@ describe('AppointmentForm', () => {
       await ReactTestUtils.Simulate.change(field('stylist'), { target: { value: 'Sara' } });
       await ReactTestUtils.Simulate.submit(form('appointment'));
     });
+
     it('filters the services list according to stylist\'s services', () => {
       const stylist = 'Jon';
       const selectableServices = ['Cut', 'Beard trim', 'Cut & Beard trim', 'Blow-dry', 'Extensions', 'Cut & color'];
@@ -197,6 +214,7 @@ describe('AppointmentForm', () => {
       render(<AppointmentForm />);
       expect(timeSlotTable()).not.toBeNull();
     });
+
     it('renders a time slot for every half an hour from open to close time', () => {
       render(<AppointmentForm salonOpensAt={9} salonClosesAt={11} />);
       const timesOfDay = timeSlotTable().querySelectorAll(
@@ -207,11 +225,13 @@ describe('AppointmentForm', () => {
       expect(timesOfDay[1].textContent).toEqual('09:30');
       expect(timesOfDay[3].textContent).toEqual('10:30');
     });
+
     it('renders an empty cell at the start of the header row', () => {
       render(<AppointmentForm />);
       const headerRow = timeSlotTable().querySelector('thead > tr');
       expect(headerRow.firstChild.textContent).toEqual('');
     });
+
     it('renders a week of available dates', () => {
       const today = new Date(2018, 11, 1);
       render(<AppointmentForm today={today} />);
@@ -223,6 +243,7 @@ describe('AppointmentForm', () => {
       expect(dates[1].textContent).toEqual('Sun 02');
       expect(dates[6].textContent).toEqual('Fri 07');
     });
+
     it('renders a radio button for each available time slot', () => {
       const today = new Date();
       const availableTimeSlots = {
@@ -242,11 +263,13 @@ describe('AppointmentForm', () => {
       expect(cells[0].querySelector('input[type="radio"]')).not.toBeNull();
       expect(cells[7].querySelector('input[type="radio"]')).not.toBeNull();
     });
+
     it('renders no radio buttons for unavailable time slots', () => {
       render(<AppointmentForm availableTimeSlots={[]} />);
       const timesOfDay = timeSlotTable().querySelectorAll('input');
       expect(timesOfDay).toHaveLength(0);
     });
+
     it('sets radio button value to the index of the corresponding appointment', () => {
       const today = new Date();
       const availableTimeSlots = {
@@ -268,6 +291,7 @@ describe('AppointmentForm', () => {
         availableTimeSlots[stylist][1].startsAt.toString()
       );
     });
+
     it('preselects the existing value', () => {
       const today = new Date();
       const availableTimeSlots = {
@@ -285,6 +309,7 @@ describe('AppointmentForm', () => {
       />);
       expect(startsAtField(0).checked).toEqual(true);
     });
+
     it('saves existing value when submiting', async () => {
       const today = new Date();
       const availableTimeSlots = {
@@ -304,6 +329,7 @@ describe('AppointmentForm', () => {
       />);
       await ReactTestUtils.Simulate.submit(form('appointment'));
     });
+
     it('saves new value when submitted', () => {
       expect.hasAssertions();
       const today = new Date();
@@ -332,6 +358,7 @@ describe('AppointmentForm', () => {
     	  ReactTestUtils.Simulate.submit(form('appointment'));
       expect(startsAtField(0).checked).toEqual(false);
     });
+
     it('renders an update timeslot table by stylist', () => {
       const today = new Date();
       const availableTimeSlots = {

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -3,7 +3,9 @@ import 'whatwg-fetch';
 import ReactTestUtils, { act } from 'react-dom/test-utils';
 import { createContainer } from './domManipulators';
 import { AppointmentForm } from '../src/AppointmentForm';
-import { fetchResponseOk, fetchResponseError, fetchRequestBody } from './spyHelpers';
+import {
+  fetchResponseOk, fetchResponseError, fetchRequestBody, fetchRequestBody2,
+} from './spyHelpers';
 
 describe('AppointmentForm', () => {
   let render;
@@ -14,6 +16,8 @@ describe('AppointmentForm', () => {
   let change;
   let submit;
 
+  let fetchSpy;
+
   beforeEach(() => {
     ({
       render, container, field, form, labelFor, change, submit,
@@ -23,9 +27,11 @@ describe('AppointmentForm', () => {
       .mockReturnValue(fetchResponseOk({}));
   });
 
-  afterEach = (() => {
+  afterEach(() => {
     window.fetch.mockRestore();
+    // window.fetch = window.fetch;
   });
+
 
   const formId = 'appointment';
 
@@ -325,12 +331,13 @@ describe('AppointmentForm', () => {
 
     it('saves existing value when submiting', async () => {
       const { startsAt } = availableTimeSlots[stylist][0];
+      const tempSpy = jest.fn;
       render(<AppointmentForm
         startsAt={startsAt}
         stylist={stylist}
       />);
-      await submit(form('appointment'));
-      expect(fetchRequestBody(window.fetch)).toMatchObject({ startsAt });
+      submit(form('appointment'));
+      expect(fetchRequestBody2(window.fetch)).toMatchObject({ startsAt });
     });
 
     it('saves new value when submitted', () => {
@@ -365,7 +372,7 @@ describe('AppointmentForm', () => {
       await act(async () => {
         submit(form('appointment'));
       });
-      expect((saveSpy)).toHaveBeenCalled();
+      expect(saveSpy).toHaveBeenCalled();
     });
 
     it('does not notify onSave when the POST request returns an error', async () => {

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -4,7 +4,7 @@ import ReactTestUtils, { act } from 'react-dom/test-utils';
 import { createContainer } from './domManipulators';
 import { AppointmentForm } from '../src/AppointmentForm';
 import {
-  fetchResponseOk, fetchResponseError, fetchRequestBody, fetchRequestBody2,
+  fetchResponseOk, fetchResponseError, fetchRequestBody,
 } from './spyHelpers';
 
 describe('AppointmentForm', () => {
@@ -313,13 +313,11 @@ describe('AppointmentForm', () => {
 
     it('saves existing value when submiting', async () => {
       const { startsAt } = availableTimeSlots[stylist][0];
-      const tempSpy = jest.fn;
       render(<AppointmentForm
         startsAt={startsAt}
-        stylist={stylist}
       />);
       submit(form('appointment'));
-      expect(fetchRequestBody2(window.fetch)).toMatchObject({ startsAt });
+      expect(fetchRequestBody(window.fetch)).toMatchObject({ startsAt });
     });
 
     it('saves new value when submitted', () => {

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -267,6 +267,18 @@ describe('AppointmentForm', () => {
     const startsAtField = (index) => container.querySelectorAll('input[name="startsAt"]') [
       index
     ];
+    const availableTimeSlots = {
+      Pepe: [
+        { startsAt: today.setHours(10, 0, 0, 0) },
+        { startsAt: today.setHours(10, 30, 0, 0) },
+
+      ],
+      Paco: [
+        { startsAt: today.setHours(9, 0, 0, 0) },
+        { startsAt: today.setHours(9, 30, 0, 0) },
+
+      ],
+    };
 
     it('renders a table for timeslots', () => {
       render(<AppointmentForm />);
@@ -302,22 +314,14 @@ describe('AppointmentForm', () => {
     });
 
     it('renders a radio button for each available time slot', () => {
-      const availableTimeSlots = {
-        Jon: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-        ],
-        Pepe: [{ startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) }],
-      };
       render(<AppointmentForm
         availableTimeSlots={availableTimeSlots}
         today={today}
         stylist="Pepe"
       />);
       const cells = timeSlotTable().querySelectorAll('td');
-      expect(cells[0].querySelector('input[type="radio"]')).not.toBeNull();
-      expect(cells[7].querySelector('input[type="radio"]')).not.toBeNull();
+      expect(cells[14].querySelector('input[type="radio"]')).not.toBeNull();
+      expect(cells[21].querySelector('input[type="radio"]')).not.toBeNull();
     });
 
     it('renders no radio buttons for unavailable time slots', () => {
@@ -327,12 +331,6 @@ describe('AppointmentForm', () => {
     });
 
     it('sets radio button value to the index of the corresponding appointment', () => {
-      const availableTimeSlots = {
-        Pepe: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-        ],
-      };
       render(<AppointmentForm
         availableTimeSlots={availableTimeSlots}
         today={today}
@@ -347,12 +345,6 @@ describe('AppointmentForm', () => {
     });
 
     it('preselects the existing value', () => {
-      const availableTimeSlots = {
-        Pepe: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-        ],
-      };
       render(<AppointmentForm
         availableTimeSlots={availableTimeSlots}
         today={today}
@@ -363,12 +355,6 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submiting', async () => {
-      const availableTimeSlots = {
-        Pepe: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-        ],
-      };
       const { startsAt } = availableTimeSlots[stylist][0];
       render(<AppointmentForm
         today={today}
@@ -383,12 +369,6 @@ describe('AppointmentForm', () => {
     });
 
     it('saves new value when submitted', () => {
-      const availableTimeSlots = {
-        Pepe: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-        ],
-      };
       const { startsAt } = availableTimeSlots[stylist][0];
       render(
         <AppointmentForm
@@ -409,18 +389,6 @@ describe('AppointmentForm', () => {
     });
 
     it('notifies onSave when form is submitted', async () => {
-      const availableTimeSlots = {
-        Pepe: [
-          { startsAt: today.setHours(10, 0, 0, 0) },
-          { startsAt: today.setHours(10, 30, 0, 0) },
-
-        ],
-        Paco: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-
-        ],
-      };
       fetchSpy.stubReturnValue(fetchResponseOk(availableTimeSlots));
       const saveSpy = spy();
       render(
@@ -438,21 +406,10 @@ describe('AppointmentForm', () => {
       expect(saveSpy).toHaveBeenCalled();
     });
 
+    it('does not notify onSave when the POST request returns an error', () => {
+    });
 
     it('renders an update timeslot table by stylist', () => {
-      const today = new Date();
-      const availableTimeSlots = {
-        Pepe: [
-          { startsAt: today.setHours(10, 0, 0, 0) },
-          { startsAt: today.setHours(10, 30, 0, 0) },
-
-        ],
-        Paco: [
-          { startsAt: today.setHours(9, 0, 0, 0) },
-          { startsAt: today.setHours(9, 30, 0, 0) },
-
-        ],
-      };
       render(<AppointmentForm
         availableTimeSlots={availableTimeSlots}
         stylist={stylist}

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -12,6 +12,15 @@ describe('AppointmentForm', () => {
   let change;
   let submit;
 
+  const spy = () => {
+    let receivedArguments;
+    return {
+      fn: (...args) => (receivedArguments = args),
+      receivedArguments: () => receivedArguments,
+      receivedArgument: (n) => receivedArguments[n],
+    };
+  };
+
   beforeEach(() => {
     ({
       render, container, field, form, labelFor, change, submit,
@@ -84,14 +93,16 @@ describe('AppointmentForm', () => {
       expect(field(formId, fieldName).id).toEqual(fieldName);
     });
 
-    it('saves existing value when submitted', async () => {
-      expect.hasAssertions();
+    it.only('saves existing value when submitted', async () => {
+      const submitSpy = spy();
+
       render(<AppointmentForm
         service="Blow-dry"
-        onSubmit={(props) => expect(props.service).toEqual('Blow-dry')}
+        onSubmit={submitSpy.fn}
       />);
-
-      await ReactTestUtils.Simulate.submit(form('appointment'));
+      submit(form('appointment'));
+      expect(submitSpy.receivedArguments()).toBeDefined();
+      expect(submitSpy.receivedArgument(0)[fieldName]).toEqual('Blow-dry');
     });
 
     it('saves a new value when submitted', async () => {
@@ -362,7 +373,7 @@ describe('AppointmentForm', () => {
           name: 'startsAt',
         },
       });
-    	  ReactTestUtils.Simulate.submit(form('appointment'));
+    	  submit(form('appointment'));
       expect(startsAtField(0).checked).toEqual(false);
     });
 

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -46,6 +46,18 @@ describe('AppointmentForm', () => {
     expect(form('appointment')).not.toBeNull();
   });
 
+  it('calls the fetch on submit and returns a 201', () => {
+    const fetchSpy = spy();
+    render(<AppointmentForm fetch={fetchSpy.fn} onSubmit={() => {}} />);
+    submit(form('appointment'));
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.receivedArgument(0)).toEqual('/appointments');
+    const fetchOpts = fetchSpy.receivedArgument(1);
+    expect(fetchOpts.method).toEqual('POST');
+    expect(fetchOpts.credentials).toEqual('same-origin');
+    expect(fetchOpts.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
   describe('service field', () => {
     const findOption = (dropdownNode, textContent) => {
       const options = Array.from(dropdownNode.childNodes);

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -7,11 +7,16 @@ describe('AppointmentForm', () => {
   let render;
   let container;
   let field;
+  let form;
+  let labelFor;
+  let change;
+  let submit;
 
   beforeEach(() => {
-    ({ render, container, field } = createContainer());
+    ({
+      render, container, field, form, labelFor, change, submit,
+    } = createContainer());
   });
-  const form = (id) => container.querySelector(`form[id="${id}"]`);
   const formId = 'appointment';
 
   it('renders a form', () => {
@@ -20,14 +25,12 @@ describe('AppointmentForm', () => {
   });
 
   describe('service field', () => {
-    // const field = (name) => form('appointment').elements[name];
     const findOption = (dropdownNode, textContent) => {
       const options = Array.from(dropdownNode.childNodes);
       return options.find(
         (option) => option.textContent === textContent
       );
     };
-    const labelFor = (formElement) => container.querySelector(`label[for="${formElement}"]`);
     const fieldName = 'service';
 
     it('renders as a select box', () => {
@@ -97,20 +100,18 @@ describe('AppointmentForm', () => {
         service="Blow-dry"
         onSubmit={(props) => expect(props.service).toEqual('Beard trim')}
       />);
-      await ReactTestUtils.Simulate.change(field(formId, fieldName), { target: { value: 'Beard trim' } });
-      await ReactTestUtils.Simulate.submit(form('appointment'));
+      change(field(formId, fieldName), { target: { value: 'Beard trim' } });
+      submit(form('appointment'));
     });
   });
 
   describe('stylist field', () => {
-    // const field = (name) => form('appointment').elements[name];
     const findOption = (dropdownNode, textContent) => {
       const options = Array.from(dropdownNode.childNodes);
       return options.find(
         (option) => option.textContent === textContent
       );
     };
-    const labelFor = (formElement) => container.querySelector(`label[for="${formElement}"]`);
     const fieldName = 'stylist';
 
     const selectableStylists = [
@@ -187,8 +188,8 @@ describe('AppointmentForm', () => {
         stylist="Pepe"
         onSubmit={(props) => expect(props.stylist).toEqual('Sara')}
       />);
-      await ReactTestUtils.Simulate.change(field(formId, fieldName), { target: { value: 'Sara' } });
-      await ReactTestUtils.Simulate.submit(form('appointment'));
+      change(field(formId, fieldName), { target: { value: 'Sara' } });
+      submit(form('appointment'));
     });
 
     it('filters the services list according to stylist\'s services', () => {
@@ -355,7 +356,7 @@ describe('AppointmentForm', () => {
           stylist={stylist}
         />
       );
-      ReactTestUtils.Simulate.change(startsAtField(1), {
+      change(startsAtField(1), {
         target: {
           value: availableTimeSlots[stylist][1].startsAt.toString(),
           name: 'startsAt',

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -4,13 +4,15 @@ import { createContainer } from './domManipulators';
 import { AppointmentForm } from '../src/AppointmentForm';
 
 describe('AppointmentForm', () => {
-  let render; let
-    container;
+  let render;
+  let container;
+  let field;
 
   beforeEach(() => {
-    ({ render, container } = createContainer());
+    ({ render, container, field } = createContainer());
   });
   const form = (id) => container.querySelector(`form[id="${id}"]`);
+  const formId = 'appointment';
 
   it('renders a form', () => {
     render(<AppointmentForm />);
@@ -18,7 +20,7 @@ describe('AppointmentForm', () => {
   });
 
   describe('service field', () => {
-    const field = (name) => form('appointment').elements[name];
+    // const field = (name) => form('appointment').elements[name];
     const findOption = (dropdownNode, textContent) => {
       const options = Array.from(dropdownNode.childNodes);
       return options.find(
@@ -26,16 +28,17 @@ describe('AppointmentForm', () => {
       );
     };
     const labelFor = (formElement) => container.querySelector(`label[for="${formElement}"]`);
+    const fieldName = 'service';
 
     it('renders as a select box', () => {
       render(<AppointmentForm />);
-      expect(field('service')).not.toBeNull();
-      expect(field('service').tagName).toEqual('SELECT');
+      expect(field(formId, fieldName)).not.toBeNull();
+      expect(field(formId, fieldName).tagName).toEqual('SELECT');
     });
 
     it('initially has a blank value chosen', () => {
       render(<AppointmentForm />);
-      const firstNode = field('service').childNodes[0];
+      const firstNode = field(formId, fieldName).childNodes[0];
       expect(firstNode.value).toEqual('');
       expect(firstNode.selected).toBeTruthy();
     });
@@ -50,7 +53,7 @@ describe('AppointmentForm', () => {
         />
       );
       const optionNodes = Array.from(
-        field('service').childNodes
+        field(formId, fieldName).childNodes
       );
       const renderedServices = optionNodes.map((node) => node.textContent);
       expect(renderedServices).toEqual(
@@ -64,18 +67,18 @@ describe('AppointmentForm', () => {
         selectedServices={services}
         service="Blow-dry"
       />);
-      const option = findOption(field('service'), 'Blow-dry');
+      const option = findOption(field(formId, fieldName), 'Blow-dry');
       expect(option.selected).toBeTruthy();
     });
 
     it('renders a label', () => {
       render(<AppointmentForm />);
-      expect(labelFor('service')).not.toBeNull();
+      expect(labelFor(fieldName)).not.toBeNull();
     });
 
     it('assigns an id that matches the label id', () => {
       render(<AppointmentForm />);
-      expect(field('service').id).toEqual('service');
+      expect(field(formId, fieldName).id).toEqual(fieldName);
     });
 
     it('saves existing value when submitted', async () => {
@@ -94,12 +97,13 @@ describe('AppointmentForm', () => {
         service="Blow-dry"
         onSubmit={(props) => expect(props.service).toEqual('Beard trim')}
       />);
-      await ReactTestUtils.Simulate.change(field('service'), { target: { value: 'Beard trim' } });
+      await ReactTestUtils.Simulate.change(field(formId, fieldName), { target: { value: 'Beard trim' } });
       await ReactTestUtils.Simulate.submit(form('appointment'));
     });
   });
+
   describe('stylist field', () => {
-    const field = (name) => form('appointment').elements[name];
+    // const field = (name) => form('appointment').elements[name];
     const findOption = (dropdownNode, textContent) => {
       const options = Array.from(dropdownNode.childNodes);
       return options.find(
@@ -107,6 +111,8 @@ describe('AppointmentForm', () => {
       );
     };
     const labelFor = (formElement) => container.querySelector(`label[for="${formElement}"]`);
+    const fieldName = 'stylist';
+
     const selectableStylists = [
       {
         name: 'Jon',
@@ -119,18 +125,18 @@ describe('AppointmentForm', () => {
 
     it('renders as a select box', () => {
       render(<AppointmentForm />);
-      expect(field('stylist')).not.toBeNull();
-      expect(field('stylist').tagName).toEqual('SELECT');
+      expect(field(formId, fieldName)).not.toBeNull();
+      expect(field(formId, fieldName).tagName).toEqual('SELECT');
     });
 
     it('renders a label for the input field', () => {
       render(<AppointmentForm />);
-      expect(labelFor('stylist')).not.toBeNull();
+      expect(labelFor(fieldName)).not.toBeNull();
     });
 
     it('initially has a blank value chosen', () => {
       render(<AppointmentForm />);
-      const firstNode = field('stylist').childNodes[0];
+      const firstNode = field(formId, fieldName).childNodes[0];
       expect(firstNode.value).toEqual('');
       expect(firstNode.selected).toBeTruthy();
     });
@@ -142,7 +148,7 @@ describe('AppointmentForm', () => {
         />
       );
       const optionNodes = Array.from(
-        field('stylist').childNodes
+        field(formId, fieldName).childNodes
       );
       const renderedStylists = optionNodes.map((node) => node.textContent);
       expect(renderedStylists).toEqual(
@@ -157,13 +163,13 @@ describe('AppointmentForm', () => {
         selectableStylists={stylists}
         stylist="Jon"
       />);
-      const option = findOption(field('stylist'), 'Jon');
+      const option = findOption(field(formId, fieldName), 'Jon');
       expect(option.selected).toBeTruthy();
     });
 
     it('assigns an id that matches the label id', () => {
       render(<AppointmentForm />);
-      expect(field('stylist').id).toEqual('stylist');
+      expect(field(formId, fieldName).id).toEqual(fieldName);
     });
 
     it('saves existing value when submitted', async () => {
@@ -181,7 +187,7 @@ describe('AppointmentForm', () => {
         stylist="Pepe"
         onSubmit={(props) => expect(props.stylist).toEqual('Sara')}
       />);
-      await ReactTestUtils.Simulate.change(field('stylist'), { target: { value: 'Sara' } });
+      await ReactTestUtils.Simulate.change(field(formId, fieldName), { target: { value: 'Sara' } });
       await ReactTestUtils.Simulate.submit(form('appointment'));
     });
 
@@ -194,7 +200,7 @@ describe('AppointmentForm', () => {
         selectableServices={selectableServices}
       />);
       const optionNodes = Array.from(
-        field('service').childNodes
+        field(formId, 'service').childNodes
       );
       const renderedServices = optionNodes.map((node) => node.textContent);
       expect(renderedServices).toEqual(expect.arrayContaining(

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -34,11 +34,21 @@ describe('AppointmentForm', () => {
 
   });
 
+  const originalFetch = window.fetch;
+  let fetchSpy;
+
   beforeEach(() => {
     ({
       render, container, field, form, labelFor, change, submit,
     } = createContainer());
+    fetchSpy = spy();
+    window.fetch = fetchSpy.fn;
   });
+
+  afterEach = () => {
+    window.fetch = originalFetch;
+  };
+
   const formId = 'appointment';
 
   it('renders a form', () => {
@@ -47,8 +57,7 @@ describe('AppointmentForm', () => {
   });
 
   it('calls the fetch on submit and returns a 201', () => {
-    const fetchSpy = spy();
-    render(<AppointmentForm fetch={fetchSpy.fn} onSubmit={() => {}} />);
+    render(<AppointmentForm onSubmit={() => {}} />);
     submit(form('appointment'));
     expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy.receivedArgument(0)).toEqual('/appointments');
@@ -119,11 +128,8 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submitted', async () => {
-      const fetchSpy = spy();
-
       render(<AppointmentForm
         service="Blow-dry"
-        fetch={fetchSpy.fn}
       />);
       submit(form('appointment'));
       const fetchOpts = fetchSpy.receivedArgument(1);
@@ -131,10 +137,8 @@ describe('AppointmentForm', () => {
     });
 
     it('saves a new value when submitted', async () => {
-      const fetchSpy = spy();
       render(<AppointmentForm
         service="Blow-dry"
-        fetch={fetchSpy.fn}
       />);
       change(field(formId, fieldName), { target: { value: 'Beard trim' } });
       submit(form('appointment'));
@@ -212,10 +216,8 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submitted', async () => {
-      const fetchSpy = spy();
       render(<AppointmentForm
         stylist="Pepe"
-        fetch={fetchSpy.fn}
       />);
       submit(form('appointment'));
       const fetchOpts = fetchSpy.receivedArgument(1);
@@ -223,10 +225,8 @@ describe('AppointmentForm', () => {
     });
 
     it('saves a new value when submitted', async () => {
-      const fetchSpy = spy();
       render(<AppointmentForm
         stylist="Pepe"
-        fetch={fetchSpy.fn}
       />);
       change(field(formId, fieldName), { target: { value: 'Sara' } });
       submit(form('appointment'));
@@ -360,7 +360,6 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submiting', async () => {
-      const fetchSpy = spy();
       const today = new Date();
       const availableTimeSlots = {
         Pepe: [
@@ -375,7 +374,6 @@ describe('AppointmentForm', () => {
         availableTimeSlots={availableTimeSlots}
         startsAt={startsAt}
         stylist={stylist}
-        fetch={fetchSpy.fn}
         onSubmit={() => {}}
       />);
       submit(form('appointment'));
@@ -384,7 +382,6 @@ describe('AppointmentForm', () => {
     });
 
     it('saves new value when submitted', () => {
-      const fetchSpy = spy();
       const today = new Date();
       const availableTimeSlots = {
         Pepe: [
@@ -399,7 +396,6 @@ describe('AppointmentForm', () => {
           availableTimeSlots={availableTimeSlots}
           today={today}
           startsAt={startsAt}
-          fetch={fetchSpy.fn}
           stylist={stylist}
         />
       );

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -124,7 +124,6 @@ describe('AppointmentForm', () => {
       render(<AppointmentForm
         service="Blow-dry"
         fetch={fetchSpy.fn}
-        onSubmit={() => {}}
       />);
       submit(form('appointment'));
       const fetchOpts = fetchSpy.receivedArgument(1);
@@ -136,7 +135,6 @@ describe('AppointmentForm', () => {
       render(<AppointmentForm
         service="Blow-dry"
         fetch={fetchSpy.fn}
-        onSubmit={() => {}}
       />);
       change(field(formId, fieldName), { target: { value: 'Beard trim' } });
       submit(form('appointment'));
@@ -217,7 +215,6 @@ describe('AppointmentForm', () => {
       const fetchSpy = spy();
       render(<AppointmentForm
         stylist="Pepe"
-        onSubmit={() => {}}
         fetch={fetchSpy.fn}
       />);
       submit(form('appointment'));
@@ -229,7 +226,6 @@ describe('AppointmentForm', () => {
       const fetchSpy = spy();
       render(<AppointmentForm
         stylist="Pepe"
-        onSubmit={() => {}}
         fetch={fetchSpy.fn}
       />);
       change(field(formId, fieldName), { target: { value: 'Sara' } });
@@ -364,6 +360,7 @@ describe('AppointmentForm', () => {
     });
 
     it('saves existing value when submiting', async () => {
+      const fetchSpy = spy();
       const today = new Date();
       const availableTimeSlots = {
         Pepe: [
@@ -372,19 +369,22 @@ describe('AppointmentForm', () => {
         ],
       };
       const stylist = 'Pepe';
-      expect.hasAssertions();
+      const { startsAt } = availableTimeSlots[stylist][0];
       render(<AppointmentForm
         today={today}
         availableTimeSlots={availableTimeSlots}
-        startsAt={availableTimeSlots[stylist][0].startsAt}
+        startsAt={startsAt}
         stylist={stylist}
-        onSubmit={({ startsAt }) => expect(startsAt).toEqual(availableTimeSlots[stylist][0].startsAt)}
+        fetch={fetchSpy.fn}
+        onSubmit={() => {}}
       />);
-      await ReactTestUtils.Simulate.submit(form('appointment'));
+      submit(form('appointment'));
+      const fetchOpts = fetchSpy.receivedArgument(1);
+      expect(JSON.parse(fetchOpts.body).startsAt).toEqual(startsAt);
     });
 
     it('saves new value when submitted', () => {
-      expect.hasAssertions();
+      const fetchSpy = spy();
       const today = new Date();
       const availableTimeSlots = {
         Pepe: [
@@ -393,12 +393,13 @@ describe('AppointmentForm', () => {
         ],
       };
       const stylist = 'Pepe';
+      const { startsAt } = availableTimeSlots[stylist][0];
       render(
         <AppointmentForm
           availableTimeSlots={availableTimeSlots}
           today={today}
-          startsAt={availableTimeSlots[stylist][0].startsAt}
-          onSubmit={({ startsAt }) => expect(startsAt).toEqual(availableTimeSlots[stylist][1].startsAt)}
+          startsAt={startsAt}
+          fetch={fetchSpy.fn}
           stylist={stylist}
         />
       );

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -317,7 +317,7 @@ describe('AppointmentForm', () => {
       render(<AppointmentForm
         availableTimeSlots={availableTimeSlots}
         today={today}
-        stylist="Pepe"
+        stylist={stylist}
       />);
       const cells = timeSlotTable().querySelectorAll('td');
       expect(cells[14].querySelector('input[type="radio"]')).not.toBeNull();
@@ -406,7 +406,31 @@ describe('AppointmentForm', () => {
       expect(saveSpy).toHaveBeenCalled();
     });
 
-    it('does not notify onSave when the POST request returns an error', () => {
+    it('does not notify onSave when the POST request returns an error', async () => {
+      fetchSpy.stubReturnValue(fetchResponseError(availableTimeSlots));
+      const saveSpy = spy();
+      render(
+        <AppointmentForm
+          availableTimeSlots={availableTimeSlots}
+          today={today}
+          // startsAt={startsAt}
+          stylist={stylist}
+          onSave={saveSpy.fn}
+        />
+      );
+      await act(async () => {
+        submit(form('appointment'));
+      });
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('prevents the default action when submitting the form', async () => {
+      const preventDefaultSpy = spy();
+      render(<AppointmentForm />);
+      await submit(form('appointment'), {
+        preventDefault: preventDefaultSpy.fn,
+      });
+      expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
     it('renders an update timeslot table by stylist', () => {

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -433,6 +433,15 @@ describe('AppointmentForm', () => {
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
+    it('renders error message when fetch call fails', async () => {
+      fetchSpy.stubReturnValue(fetchResponseError());
+      render(<AppointmentForm />);
+      await submit(form('appointment'));
+      const errorElement = container.querySelector('.error');
+      expect(errorElement).not.toBeNull();
+      expect(errorElement.textContent).toMatch('error occured');
+    });
+
     it('renders an update timeslot table by stylist', () => {
       render(<AppointmentForm
         availableTimeSlots={availableTimeSlots}

--- a/test/AppointmentForm.test.js
+++ b/test/AppointmentForm.test.js
@@ -29,7 +29,6 @@ describe('AppointmentForm', () => {
 
   afterEach(() => {
     window.fetch.mockRestore();
-    // window.fetch = window.fetch;
   });
 
 
@@ -53,27 +52,99 @@ describe('AppointmentForm', () => {
     );
   });
 
-	  describe('service field', () => {
-    const findOption = (dropdownNode, textContent) => {
-      const options = Array.from(dropdownNode.childNodes);
-      return options.find(
-        (option) => option.textContent === textContent
-      );
-    };
-    const fieldName = 'service';
+  const selectableStylists = [
+    {
+      name: 'Jon',
+      services: ['Cut', 'Blow-dry', 'Beard trim', 'Cut & Beard trim'],
+    },
+    {
+      name: 'Jane',
+      services: ['Blow-dry', 'Extensions', 'Cut & color', 'Cut'],
+    }];
 
+
+  const findOption = (dropdownNode, textContent) => {
+    const options = Array.from(dropdownNode.childNodes);
+    return options.find(
+      (option) => option.textContent === textContent
+    );
+  };
+
+  const rendersSelectBox = (fieldName) => {
     it('renders as a select box', () => {
       render(<AppointmentForm />);
       expect(field(formId, fieldName)).not.toBeNull();
       expect(field(formId, fieldName).tagName).toEqual('SELECT');
     });
+  };
 
+  const hasBlankValue = (fieldName) => {
     it('initially has a blank value chosen', () => {
       render(<AppointmentForm />);
       const firstNode = field(formId, fieldName).childNodes[0];
       expect(firstNode.value).toEqual('');
       expect(firstNode.selected).toBeTruthy();
     });
+  };
+
+  const rendersLabelForInputField = (fieldName) => {
+    it('renders a label for the input field', () => {
+      render(<AppointmentForm />);
+      expect(labelFor(fieldName)).not.toBeNull();
+    });
+  };
+
+  const preselectsExistingValue = (fieldName, value) => {
+    it('preselects the existing value', () => {
+      // const services = ['Cut', 'Blow-dry'];
+      render(<AppointmentForm
+        {...{ [fieldName]: value }}
+      />);
+      const option = findOption(field(formId, fieldName), value);
+      expect(option.selected).toBeTruthy();
+    });
+  };
+
+  const assignsMatchingId = (fieldName) => {
+    it('assigns an id that matches the label id', () => {
+      render(<AppointmentForm />);
+      expect(field(formId, fieldName).id).toEqual(fieldName);
+    });
+  };
+
+  const saveExistingValue = (fieldName, value) => {
+    it('saves existing value when submitted', async () => {
+      render(<AppointmentForm
+        {...{ [fieldName]: value }}
+      />);
+      submit(form('appointment'));
+      expect(fetchRequestBody(window.fetch)[fieldName])
+        .toEqual(value);
+    });
+  };
+
+  const saveNewValue = (fieldName, oldValue, newValue) => {
+    it('saves a new value when submitted', async () => {
+      render(<AppointmentForm
+        {...{ [fieldName]: oldValue }}
+        selectableStylists={selectableStylists}
+      />);
+      change(field(formId, fieldName), { target: { value: newValue } });
+      submit(form('appointment'));
+      expect(fetchRequestBody(window.fetch)[fieldName]).toEqual(newValue);
+    });
+  };
+
+	  describe('service field', () => {
+    const fieldName = 'service';
+
+    rendersSelectBox(fieldName);
+    hasBlankValue(fieldName);
+    rendersLabelForInputField(fieldName);
+    preselectsExistingValue(fieldName, 'Blow-dry');
+    assignsMatchingId(fieldName);
+    saveExistingValue(fieldName, 'Blow-dry');
+    saveNewValue(fieldName, 'Blow-dry', 'Cut');
 
     it('lists all salon services', () => {
       const selectableServices = [
@@ -92,44 +163,8 @@ describe('AppointmentForm', () => {
         expect.arrayContaining(selectableServices)
       );
     });
-
-    it('preselects the existing value', () => {
-      const services = ['Cut', 'Blow-dry'];
-      render(<AppointmentForm
-        selectedServices={services}
-        service="Blow-dry"
-      />);
-      const option = findOption(field(formId, fieldName), 'Blow-dry');
-      expect(option.selected).toBeTruthy();
-    });
-
-    it('renders a label', () => {
-      render(<AppointmentForm />);
-      expect(labelFor(fieldName)).not.toBeNull();
-    });
-
-    it('assigns an id that matches the label id', () => {
-      render(<AppointmentForm />);
-      expect(field(formId, fieldName).id).toEqual(fieldName);
-    });
-
-    it('saves existing value when submitted', async () => {
-      render(<AppointmentForm
-        service="Blow-dry"
-      />);
-      submit(form('appointment'));
-      expect(fetchRequestBody(window.fetch)[fieldName]).toEqual('Blow-dry');
-    });
-
-    it('saves a new value when submitted', async () => {
-      render(<AppointmentForm
-        service="Blow-dry"
-      />);
-      change(field(formId, fieldName), { target: { value: 'Beard trim' } });
-      submit(form('appointment'));
-      expect(fetchRequestBody(window.fetch)[fieldName]).toEqual('Beard trim');
-    });
   });
+
 
   describe('stylist field', () => {
     const findOption = (dropdownNode, textContent) => {
@@ -140,33 +175,13 @@ describe('AppointmentForm', () => {
     };
     const fieldName = 'stylist';
 
-    const selectableStylists = [
-      {
-        name: 'Jon',
-        services: ['Cut', 'Blow-dry', 'Beard trim', 'Cut & Beard trim'],
-      },
-      {
-        name: 'Jane',
-        services: ['Blow-dry', 'Extensions', 'Cut & color', 'Cut'],
-      }];
-
-    it('renders as a select box', () => {
-      render(<AppointmentForm />);
-      expect(field(formId, fieldName)).not.toBeNull();
-      expect(field(formId, fieldName).tagName).toEqual('SELECT');
-    });
-
-    it('renders a label for the input field', () => {
-      render(<AppointmentForm />);
-      expect(labelFor(fieldName)).not.toBeNull();
-    });
-
-    it('initially has a blank value chosen', () => {
-      render(<AppointmentForm />);
-      const firstNode = field(formId, fieldName).childNodes[0];
-      expect(firstNode.value).toEqual('');
-      expect(firstNode.selected).toBeTruthy();
-    });
+    rendersSelectBox(fieldName);
+    hasBlankValue(fieldName);
+    rendersLabelForInputField(fieldName);
+    preselectsExistingValue(fieldName, 'Jon');
+    assignsMatchingId(fieldName);
+    saveExistingValue(fieldName, 'Jon');
+    saveNewValue(fieldName, 'Jon', 'Jane');
 
     it('lists all stylists', () => {
       render(
@@ -181,39 +196,6 @@ describe('AppointmentForm', () => {
       expect(renderedStylists).toEqual(
         expect.arrayContaining(selectableStylists.map((s) => s.name))
       );
-    });
-
-    it('preselects the existing value', () => {
-      const stylists = [{ name: 'Jon', services: ['Cut', 'Cut & color'] },
-        { name: 'Jeff', services: ['Extensions', 'Cut'] }];
-      render(<AppointmentForm
-        selectableStylists={stylists}
-        stylist="Jon"
-      />);
-      const option = findOption(field(formId, fieldName), 'Jon');
-      expect(option.selected).toBeTruthy();
-    });
-
-    it('assigns an id that matches the label id', () => {
-      render(<AppointmentForm />);
-      expect(field(formId, fieldName).id).toEqual(fieldName);
-    });
-
-    it('saves existing value when submitted', async () => {
-      render(<AppointmentForm
-        stylist="Pepe"
-      />);
-      submit(form('appointment'));
-      expect(fetchRequestBody(window.fetch)[fieldName]).toEqual('Pepe');
-    });
-
-    it('saves a new value when submitted', async () => {
-      render(<AppointmentForm
-        stylist="Pepe"
-      />);
-      change(field(formId, fieldName), { target: { value: 'Sara' } });
-      submit(form('appointment'));
-      expect(fetchRequestBody(window.fetch)[fieldName]).toEqual('Sara');
     });
 
     it('filters the services list according to stylist\'s services', () => {

--- a/test/CustomerForm.test.jsx
+++ b/test/CustomerForm.test.jsx
@@ -157,6 +157,11 @@ describe('CustomerForm', () => {
     expect(errorElement.textContent).toMatch('error occured');
   });
   it('clears the error state when the form succeeds', async () => {
+    window.fetch.mockReturnValueOnce(fetchResponseError());
     window.fetch.mockReturnValue(fetchResponseOk());
+    render(<CustomerForm />);
+    await submit(form('customer'));
+    await submit(form('customer'));
+    expect(element('.error')).toBeNull();
   });
 });

--- a/test/CustomerForm.test.jsx
+++ b/test/CustomerForm.test.jsx
@@ -40,8 +40,6 @@ describe('CustomerForm', () => {
     expect(form('customer')).not.toBeNull();
   });
 
-  // const field = (formId, name) => form(formId).elements[name];
-
   const itRendersAsATextBox = (fieldName) => it('renders as a test box', () => {
     render(<CustomerForm />);
     expectToBeInputFieldOfTypeText(field('customer', fieldName));
@@ -50,7 +48,6 @@ describe('CustomerForm', () => {
     render(<CustomerForm {...{ [fieldName]: 'value' }} />);
     expect(field('customer', fieldName).value).toEqual('value');
   });
-  // const labelFor = (formElement) => element(`label[for="${formElement}"]`);
   const itRendersALabel = (fieldName) => it('renders a label', () => {
     render(<CustomerForm />);
     expect(labelFor(fieldName)).not.toBeNull();

--- a/test/CustomerForm.test.jsx
+++ b/test/CustomerForm.test.jsx
@@ -149,11 +149,14 @@ describe('CustomerForm', () => {
     expect(preventDefaultSpy).toHaveBeenCalled();
   });
   it('renders error message when fetch call fails', async () => {
-    window.fetch.mockReturnValue(Promise.resolve({ ok: false }));
+    window.fetch.mockReturnValue(fetchResponseError());
     render(<CustomerForm />);
     await submit(form('customer'));
     const errorElement = element('.error');
     expect(errorElement).not.toBeNull();
     expect(errorElement.textContent).toMatch('error occured');
+  });
+  it('clears the error state when the form succeeds', async () => {
+    window.fetch.mockReturnValue(fetchResponseOk());
   });
 });

--- a/test/CustomerForm.test.jsx
+++ b/test/CustomerForm.test.jsx
@@ -27,7 +27,6 @@ describe('CustomerForm', () => {
   afterEach(() => {
     window.fetch.mockRestore();
   });
-  // const form = (id) => element(`form[id="${id}"]`);
 
   const expectToBeInputFieldOfTypeText = (formElement) => {
 	  expect(formElement).not.toBeNull();

--- a/test/spyHelpers.js
+++ b/test/spyHelpers.js
@@ -8,3 +8,5 @@ export const fetchResponseError = () => {
 };
 
 export const fetchRequestBody = (fetchSpy) => JSON.parse(fetchSpy.mock.calls[0][1].body);
+
+export const fetchRequestBody2 = (fetchSpy) => JSON.parse(fetchSpy.mock.calls[0][1].body);


### PR DESCRIPTION
- [x]  Add a test to `CustomerForm` tests that specifies that the error state is cleared on a successful  submit.
- [ ] update `AppointmentForm` with : `jest.fn` and `jest.spyOn` and all the helpers in `domManipulators.js` and `spyHelpers.js`
- [ ] Extend `AppointmentForm` so it submits a POST request to `/appointments` endpoint and returns 201 `Created` status without any body.
- [ ] update the tests in `AppointmentsDayView` to use the new helpers from `test/domManipulators.js`